### PR TITLE
Compatibilité /bin/sh lors de la création de l'env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ github: publish
 
 virtualenv:
 	if [ ! -f $(PYTHON) ]; then \
-	    if [[ "`$(VIRTUALENV) --version`" < "`echo '1.8'`" ]]; then \
+	    if expr "`$(VIRTUALENV) --version`" "<" "1.8"; then \
 		$(VIRTUALENV) --no-site-packages --distribute -p python env; \
 	    else \
 		$(VIRTUALENV) -p python env; \


### PR DESCRIPTION
Avec master, j'ai cette erreur :

```
if [ ! -f env/bin/python ]; then \
    if [[ "`virtualenv --version`" < "`echo '1.8'`" ]]; then \
        virtualenv --no-site-packages --distribute -p python env; \
    else \
        virtualenv -p python env; \
    fi; \
fi;
/bin/sh: 2: cannot open 1.8: No such file
/bin/sh: 2: [[: not found
Already using interpreter /usr/bin/python
New python executable in env/bin/python
Installing setuptools, pip...done.
```

Cette PR la corrige.